### PR TITLE
Overflow patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ function hash(string, a, num_buckets):
 # Limitations
 - only accepts char* and ASCII
 - collisions are handled with open addressing with double hashing.
+- Handle int/long overflows correctly!
+- Hash tables of size ~ million don't have great performance
 TODO: change/mitigate these!
 
 # Run unit tests

--- a/test/test.cc
+++ b/test/test.cc
@@ -152,3 +152,50 @@ TEST(HashTable, LargePutAndSearch) {
     }
     ht_del_hash_table(ht);
 }
+
+
+// ---------------------- HUGE ----------------------
+
+TEST(HashTable, HugePut) {
+    ht_hash_table* ht = ht_new();
+    char buffer[20];
+
+    for (int i = 0; i < 1000000; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ht_insert(ht, buffer, buffer);
+    }
+
+    ht_del_hash_table(ht);
+}
+
+TEST(HashTable, HugePutAndDelete) {
+    ht_hash_table* ht = ht_new();
+    char buffer[20];
+
+    for (int i = 0; i < 1000000; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ht_insert(ht, buffer, buffer);
+    }
+
+    for (int i = 0; i < 1000000; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ht_delete(ht, buffer);
+    }
+    ht_del_hash_table(ht);
+}
+
+TEST(HashTable, HugePutAndSearch) {
+    ht_hash_table* ht = ht_new();
+    char buffer[20];
+
+    for (int i = 0; i < 1000000; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ht_insert(ht, buffer, buffer);
+    }
+
+    for (int i = 0; i < 1000000; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ASSERT_EQ(strcmp(ht_search(ht, buffer), buffer), 0);
+    }
+    ht_del_hash_table(ht);
+}

--- a/test/test.cc
+++ b/test/test.cc
@@ -4,8 +4,26 @@ extern "C" {
     #include "../src/hash_table.h"
 }
 
+
+// ---------------------- Init ----------------------
+
 TEST(HashTable, InitTest) {
     ht_hash_table* ht = ht_new();
+    ht_del_hash_table(ht);
+}
+
+
+// ---------------------- Small ----------------------
+
+TEST(HashTable, SmallPut) {
+    ht_hash_table* ht = ht_new();
+    char buffer[20];
+
+    for (int i = 0; i < 10; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ht_insert(ht, buffer, buffer);
+    }
+
     ht_del_hash_table(ht);
 }
 
@@ -35,6 +53,100 @@ TEST(HashTable, SmallPutAndSearch) {
     }
 
     for (int i = 0; i < 10; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ASSERT_EQ(strcmp(ht_search(ht, buffer), buffer), 0);
+    }
+    ht_del_hash_table(ht);
+}
+
+
+// ---------------------- Medium ----------------------
+
+TEST(HashTable, MediumPut) {
+    ht_hash_table* ht = ht_new();
+    char buffer[20];
+
+    for (int i = 0; i < 100; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ht_insert(ht, buffer, buffer);
+    }
+
+    ht_del_hash_table(ht);
+}
+
+TEST(HashTable, MediumPutAndDelete) {
+    ht_hash_table* ht = ht_new();
+    char buffer[20];
+
+    for (int i = 0; i < 100; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ht_insert(ht, buffer, buffer);
+    }
+
+    for (int i = 0; i < 100; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ht_delete(ht, buffer);
+    }
+    ht_del_hash_table(ht);
+}
+
+TEST(HashTable, MediumPutAndSearch) {
+    ht_hash_table* ht = ht_new();
+    char buffer[20];
+
+    for (int i = 0; i < 100; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ht_insert(ht, buffer, buffer);
+    }
+
+    for (int i = 0; i < 100; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ASSERT_EQ(strcmp(ht_search(ht, buffer), buffer), 0);
+    }
+    ht_del_hash_table(ht);
+}
+
+
+// ---------------------- Large ----------------------
+
+TEST(HashTable, LargePut) {
+    ht_hash_table* ht = ht_new();
+    char buffer[20];
+
+    for (int i = 0; i < 10000; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ht_insert(ht, buffer, buffer);
+    }
+
+    ht_del_hash_table(ht);
+}
+
+TEST(HashTable, LargePutAndDelete) {
+    ht_hash_table* ht = ht_new();
+    char buffer[20];
+
+    for (int i = 0; i < 10000; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ht_insert(ht, buffer, buffer);
+    }
+
+    for (int i = 0; i < 10000; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ht_delete(ht, buffer);
+    }
+    ht_del_hash_table(ht);
+}
+
+TEST(HashTable, LargePutAndSearch) {
+    ht_hash_table* ht = ht_new();
+    char buffer[20];
+
+    for (int i = 0; i < 10000; i++) {
+        snprintf(buffer, sizeof(buffer), "%d", i);
+        ht_insert(ht, buffer, buffer);
+    }
+
+    for (int i = 0; i < 10000; i++) {
         snprintf(buffer, sizeof(buffer), "%d", i);
         ASSERT_EQ(strcmp(ht_search(ht, buffer), buffer), 0);
     }


### PR DESCRIPTION
This PR:
- increased unit test coverage
- changed hash function return type to long to mitigate overflow
- added abs() to stop negative indexing on items array, causing seg fault.